### PR TITLE
Make module more flexible

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ module "dashboard" {
   rds_free_storage_max = 100 * 1000 * 1000 * 1000   # 100 gb
   rds_iops_max         = 200
 
-  rds_instance = "jrr-db"
+  rds_instances = [
+    "jrr-db"
+  ]
 }
 
 ```
@@ -63,7 +65,7 @@ The following arguments are supported:
 
 * `rds_iops_max` – (Optional) Maximum IOPS value plotted on Y axis. By default, CloudWatch chooses the maximum Y value based on the data values in the period.
 
-* `rds_instance` – (Optional) RDS instance to be displayed on dashboard. **NOTE:** Currently, this module supports only one RDS instance per dashboard.
+* `rds_instances` – (Optional) List of RDS instances to be displayed on dashboard.
 
 Attributes Reference
 --------------------

--- a/data.tf
+++ b/data.tf
@@ -1,6 +1,0 @@
-data "aws_region" "current" {}
-
-locals {
-  widget_height = 6
-  widget_width  = 8
-}

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,36 @@
+data "aws_region" "current" {}
+
 locals {
-  widgets = concat(local.ecs_widget_definition, local.rds_widget_definition)
+  # Define widget geometry.
+  geo = {
+    height = 6
+    width  = 8
+  }
+}
+
+module "ecs" {
+  source = "./modules/ecs"
+
+  instances   = var.ecs_containers
+  period      = var.period
+  ecs_cluster = var.ecs_cluster
+  region      = data.aws_region.current.name
+  geo         = local.geo
+}
+
+module "rds" {
+  source = "./modules/rds"
+
+  instances            = var.rds_instances
+  period               = var.period
+  rds_free_storage_max = var.rds_free_storage_max
+  rds_iops_max         = var.rds_iops_max
+  region               = data.aws_region.current.name
+  geo                  = local.geo
+}
+
+locals {
+  widgets = concat(module.ecs.widget_definition, module.rds.widget_definition)
 }
 
 resource "aws_cloudwatch_dashboard" "default" {

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -1,12 +1,10 @@
-# TODO: Need to make this work if var.ecs_containers is empty.
-
 locals {
-  ecs_widget_definition = [
+  widget_definition = [
     {
-      height = local.widget_height
+      height = var.geo.height
       properties = {
         metrics = [
-          for container in sort(var.ecs_containers) : [
+          for container in sort(var.instances) : [
             "AWS/ECS",
             "CPUUtilization",
             "ServiceName",
@@ -16,7 +14,7 @@ locals {
           ]
         ]
         period  = var.period
-        region  = data.aws_region.current.name
+        region  = var.region
         stacked = false
         stat    = "Average"
         title   = "ECS CPU utilization"
@@ -30,17 +28,17 @@ locals {
         }
       }
       type  = "metric"
-      width = local.widget_width
+      width = var.geo.width
       # TODO: Don't set position if no ECS widgets are defined.
       x = 0
       y = 0
     },
 
     {
-      height = local.widget_height
+      height = var.geo.height
       properties = {
         metrics = [
-          for container in sort(var.ecs_containers) : [
+          for container in sort(var.instances) : [
             "AWS/ECS",
             "MemoryUtilization",
             "ServiceName",
@@ -50,7 +48,7 @@ locals {
           ]
         ]
         period  = var.period
-        region  = data.aws_region.current.name
+        region  = var.region
         stacked = false
         stat    = "Average"
         title   = "ECS memory utilization"
@@ -64,9 +62,9 @@ locals {
         }
       }
       type  = "metric"
-      width = local.widget_width
+      width = var.geo.width
       # TODO: Don't set position if no ECS widgets are defined.
-      x = local.widget_width
+      x = var.geo.width
       y = 0
     }
   ]

--- a/modules/ecs/outputs.tf
+++ b/modules/ecs/outputs.tf
@@ -1,0 +1,3 @@
+output "widget_definition" {
+  value = local.widget_definition
+}

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -1,0 +1,9 @@
+variable "ecs_cluster" {}
+
+variable "geo" {}
+
+variable "instances" {}
+
+variable "period" {}
+
+variable "region" {}

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -1,27 +1,26 @@
-# TODO: Need to make this work if var.rds_instances is empty.
-# TODO: Need to make this work for multiple var.rds_instances.
+locals {
+  rds_io_metrics      = ["ReadIOPS", "WriteIOPS"]
+  rds_storage_metrics = ["FreeStorageSpace"]
+}
 
 locals {
-  rds_io_metrics     = ["ReadIOPS", "WriteIOPS"]
-  rds_memory_metrics = ["FreeStorageSpace"]
-
-  rds_widget_definition = [
-    {
-      height = local.widget_height
+  widget_definition_io = [
+    for instance in var.instances : {
+      height = var.geo.height
       properties = {
         metrics = [
           for metric in local.rds_io_metrics : [
             "AWS/RDS",
             metric,
             "DBInstanceIdentifier",
-            var.rds_instance,
+            instance,
           ]
         ]
         period  = var.period
-        region  = data.aws_region.current.name
+        region  = var.region
         stacked = false
         stat    = "Average"
-        title   = "RDS IOPS (${var.rds_instance})"
+        title   = format("RDS IOPS (%s)", instance)
         view    = "timeSeries"
         yAxis = {
           left = {
@@ -30,32 +29,31 @@ locals {
           }
         }
       }
-      type  = "metric"
-      width = local.widget_width
-      # TODO: Don't set position if no RDS widgets are defined.
-      x = 0
-      y = local.widget_height
-    },
+    }
+  ]
+}
 
-    {
-      height = local.widget_height
+locals {
+  widget_definition_storage = [
+    for instance in var.instances : {
+      height = var.geo.height
       properties = {
         metrics = [
-          for metric in local.rds_memory_metrics : [
+          for metric in local.rds_storage_metrics : [
             "AWS/RDS",
             metric,
             "DBInstanceIdentifier",
-            var.rds_instance,
+            instance,
             {
               label = "FreeStorageSpace"
             }
           ]
         ]
         period  = var.period
-        region  = data.aws_region.current.name
+        region  = var.region
         stacked = false
         stat    = "Average"
-        title   = "RDS free storage (${var.rds_instance})"
+        title   = format("RDS free storage (%s)", instance)
         view    = "timeSeries"
         yAxis = {
           left = {
@@ -65,10 +63,10 @@ locals {
         }
       }
       type  = "metric"
-      width = local.widget_width
+      width = var.geo.width
       # TODO: Don't set position if no RDS widgets are defined.
-      x = local.widget_width
-      y = local.widget_height
+      x = var.geo.width
+      y = var.geo.height
     }
   ]
 }

--- a/modules/rds/outputs.tf
+++ b/modules/rds/outputs.tf
@@ -1,0 +1,3 @@
+output "widget_definition" {
+  value = concat(local.widget_definition_io, local.widget_definition_storage)
+}

--- a/modules/rds/variables.tf
+++ b/modules/rds/variables.tf
@@ -1,0 +1,11 @@
+variable "geo" {}
+
+variable "instances" {}
+
+variable "period" {}
+
+variable "rds_free_storage_max" {}
+
+variable "rds_iops_max" {}
+
+variable "region" {}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
-output "dashboard_arn" {
-  value = aws_cloudwatch_dashboard.default.dashboard_arn
-}
+#output "dashboard_arn" {
+# value = aws_cloudwatch_dashboard.default.dashboard_arn
+#}
 
 # TODO: This is for debugging.
 

--- a/variables.tf
+++ b/variables.tf
@@ -30,8 +30,8 @@ variable "rds_iops_max" {
   type        = number
 }
 
-variable "rds_instance" {
-  default     = null
-  type        = string
-  description = "RDS instance to be displayed on dashboard"
+variable "rds_instances" {
+  default     = []
+  type        = list(string)
+  description = "List of RDS instances to be displayed on dashboard"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 1.1"
 }


### PR DESCRIPTION
*   IAMU has a use case wherein the central-registry dashboard does not include any RDS instance; fix code to support arbitrarily many RDS instances.

*   Move widget code into individual modules.